### PR TITLE
chore: bump node engine to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": "^18.0.0"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
## Summary
- Node 18 is discontinued; Vercel now requires `engines.node` set to `24.x`
- Update `package.json` `engines.node` from `^18.0.0` to `24.x` to fix the failing deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)