### PR TITLE
chore: temporarily take notes section offline

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,23 @@ const nextConfig = {
       },
     ];
   },
+  // Temporarily take the notes section offline while the backend is migrated.
+  // To re-enable: remove this redirects block and uncomment the nav entry in
+  // src/components/Nav/index.tsx.
+  redirects: () => {
+    return [
+      {
+        source: '/notes',
+        destination: '/',
+        permanent: false,
+      },
+      {
+        source: '/notes/:path*',
+        destination: '/',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   setBackground: Function;
 }
 
-const NAV_LIST = [
+const NAV_LIST: { name: string; path: string; className?: string }[] = [
   { name: 'home', path: '/' },
   { name: 'blog', path: '/blog' },
   { name: 'projects', path: '/projects' },

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -19,7 +19,8 @@ const NAV_LIST = [
   { name: 'home', path: '/' },
   { name: 'blog', path: '/blog' },
   { name: 'projects', path: '/projects' },
-  { name: 'notes', path: '/notes', className: 'hidden sm:flex' },
+  // Temporarily offline while the notes backend is being migrated.
+  // { name: 'notes', path: '/notes', className: 'hidden sm:flex' },
 ];
 
 const TEXT_COLOR =


### PR DESCRIPTION
## What

Temporarily takes the **Notes** section offline while the notes backend (Strapi at `yuanx-strapi.zeabur.app`) is being migrated.

## Changes

- **Hide nav entry** — commented out the `notes` item in `NAV_LIST` (`src/components/Nav/index.tsx`) so it no longer appears in the menu.
- **Redirect the route** — added a temporary `redirects` block in `next.config.js` sending `/notes` and `/notes/*` to `/` (`permanent: false` → 307, so it isn't cached by browsers/SEO). This prevents direct URL access from hitting the down backend and getting stuck loading/erroring.

## Intentionally left intact (for easy re-enable)

- The `/notes` page, `AddNote` / `NoteNode` components, and the `useNotes` hook
- The `/api/notes/*` → Strapi rewrite in `next.config.js`
- The notes-related logic in `_app.tsx`

## How to re-enable after migration

1. Remove the `redirects` block in `next.config.js`.
2. Uncomment the notes entry in `src/components/Nav/index.tsx`.
3. If the Strapi backend URL changed during migration, update the rewrite `destination`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)